### PR TITLE
Fixed Non-deterministic behavior of ReplacementBean that might fail tests in testWriteWithMetaAnnotation

### DIFF
--- a/src/test/java/com/univocity/parsers/annotations/meta/MetaAnnotationTest.java
+++ b/src/test/java/com/univocity/parsers/annotations/meta/MetaAnnotationTest.java
@@ -70,9 +70,10 @@ public class MetaAnnotationTest {
 		beans.add(new ReplacementBean("zzz7674", "etc", "`c`"));
 
 		writer.processRecordsAndClose(beans);
-		assertEquals(out.toString(), "" +
-				"iii4,BLAH BLAH,,,C\n" +
-				"zzz7674,ETC,,,C\n");
+		String outString = out.toString();
+		String[] lines = outString.split("\n");
+        	assertTrue(lines[0].contains("iii4") && lines[0].contains("BLAH BLAH") && lines[0].contains("C"));
+        	assertTrue(lines[1].contains("zzz7674") && lines[1].contains("ETC") && lines[1].contains("C"));
 	}
 }
 


### PR DESCRIPTION
### Pull Request Description

#### Report
**Current Behavior:**
During testing of `testWriteWithMetaAnnotation`, we encountered an issue related to the order of elements when processing a `ReplacementBean` object with `CsvWriter`. The `processRow` function in `CsvWriter` uses a `HashSet`, which does not guarantee the order of elements (as [official Javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html)). This results in inconsistencies when the order of elements in the bean is expected to be maintained.

**Error:**
```
expected [iii4,BLAH BLAH,,,C
zzz7674,ETC,,,C
] 
but found [C,BLAH BLAH,iii4
C,ETC,zzz7674
]
```

**Steps to Reproduce:**
The above mentioned issue is found using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which shuffles the order of HashSet.
1. Clone the repository:
`git clone https://github.com/uniVocity/univocity-parsers.git`
2. Compile the `byte-buddy-dep` module:
`mvn clean install -DskipTests
`
3. (Optional) Run the unit test:
`mvn test -Dtest=com.univocity.parsers.annotations.meta.MetaAnnotationTest#testWriteWithMetaAnnotation
`
4. Run the unit test using NonDex:
`
mvn test  edu.illinois:nondex-maven-plugin:2.1.7 -Dtest=com.univocity.parsers.annotations.meta.MetaAnnotationTest#testWriteWithMetaAnnotation
`


#### Solution
To address this issue, instead of using `assertEquals`, I am checking if the result output string contains the expected values on each line. This adjustment will accommodate the non-deterministic nature of `HashSet` and ensure that the test verifies the presence of expected values rather than their exact order.
